### PR TITLE
[JENKINS-51837] - Update ASM to 6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
  <artifactId>asm6</artifactId>
- <version>6.0_BETA-2-SNAPSHOT</version>
+ <version>6.2-SNAPSHOT</version>
 
  <name>asm6</name>
  <description>ObjectWeb ASM package-renamed to isolate incompatibilities between major versions</description>
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-debug-all</artifactId>
-      <version>6.0_BETA</version>
+      <version>6.2</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,12 +31,41 @@
     <tag>HEAD</tag>
   </scm>
 
+  <properties>
+    <asm.version>6.2</asm.version>
+  </properties>
+
  <dependencies>
     <dependency>
       <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-debug-all</artifactId>
-      <version>6.2</version>
+      <artifactId>asm</artifactId>
+      <version>${asm.version}</version>
     </dependency>
+   <dependency>
+     <groupId>org.ow2.asm</groupId>
+     <artifactId>asm-analysis</artifactId>
+     <version>${asm.version}</version>
+   </dependency>
+   <dependency>
+     <groupId>org.ow2.asm</groupId>
+     <artifactId>asm-commons</artifactId>
+     <version>${asm.version}</version>
+   </dependency>
+   <dependency>
+     <groupId>org.ow2.asm</groupId>
+     <artifactId>asm-tree</artifactId>
+     <version>${asm.version}</version>
+   </dependency>
+   <dependency>
+     <groupId>org.ow2.asm</groupId>
+     <artifactId>asm-util</artifactId>
+     <version>${asm.version}</version>
+   </dependency>
+   <dependency>
+     <groupId>org.ow2.asm</groupId>
+     <artifactId>asm-xml</artifactId>
+     <version>${asm.version}</version>
+   </dependency>
   </dependencies>
 
  <build>


### PR DESCRIPTION
This is required for https://issues.jenkins-ci.org/browse/JENKINS-51837 and finally for https://issues.jenkins-ci.org/browse/JENKINS-46602 (running Jenkins Pipeline with Java 10). 

CC @batmat @kohsuke 
